### PR TITLE
🎨 Replace AndroidDataFlow magic number with constant

### DIFF
--- a/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
@@ -34,9 +34,7 @@ import kotlinx.coroutines.channels.actor
  *
  * @param defaultCapacity
  * The default capacity of this `DataFlow`.
- * If [setState] or [sendEvent] are called in quick
- * succession, faster than the observers can be notified, then the buffer will be used.
- * Any state actions dispatched using `setState` will be added to the buffer unless it's full.
+ * Any state actions dispatched using [setState] will be added to the buffer unless it's full.
  * Defaults to [Channel.BUFFERED].
  *
  * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
@@ -26,6 +26,22 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
 
+/**
+ * Android implementation of [DataFlow].
+ * This is also a [ViewModel].
+ * Its [coroutineScope] uses [Dispatchers.Main] and is automatically cancelled if the `ViewModel`
+ * is cleared.
+ *
+ * @param defaultCapacity
+ * The default capacity of this `DataFlow`.
+ * If [setState] or [sendEvent] are called in quick
+ * succession, faster than the observers can be notified, then the buffer will be used.
+ * Any `setState` or `sendEvent` calls will be added to the buffer unless it's full.
+ * Defaults to [Channel.BUFFERED].
+ *
+ * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.
+ * Defaults to [Dispatchers.IO].
+ */
 abstract class AndroidDataFlow(
     defaultCapacity: Int = Channel.BUFFERED,
     override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
@@ -25,7 +25,11 @@ import io.uniflow.core.threading.onMain
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.actor
 
-abstract class AndroidDataFlow(defaultCapacity: Int = 10, override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()) : ViewModel(), DataFlow {
+abstract class AndroidDataFlow(
+    defaultCapacity: Int = 10,
+    override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()
+) : ViewModel(),
+    DataFlow {
 
     private val viewModelJob = SupervisorJob()
     override val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main + viewModelJob)

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.channels.actor
  * The default capacity of this `DataFlow`.
  * If [setState] or [sendEvent] are called in quick
  * succession, faster than the observers can be notified, then the buffer will be used.
- * Any `setState` or `sendEvent` calls will be added to the buffer unless it's full.
+ * Any state actions dispatched using `setState` will be added to the buffer unless it's full.
  * Defaults to [Channel.BUFFERED].
  *
  * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/AndroidDataFlow.kt
@@ -23,10 +23,11 @@ import io.uniflow.core.flow.*
 import io.uniflow.core.logger.UniFlowLogger
 import io.uniflow.core.threading.onMain
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
 
 abstract class AndroidDataFlow(
-    defaultCapacity: Int = 10,
+    defaultCapacity: Int = Channel.BUFFERED,
     override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()
 ) : ViewModel(),
     DataFlow {

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
@@ -34,9 +34,7 @@ import kotlinx.coroutines.channels.actor
  *
  * @param defaultCapacity
  * The default capacity of this `DataFlow`.
- * If [setState] or [sendEvent] are called in quick
- * succession, faster than the observers can be notified, then the buffer will be used.
- * Any state actions dispatched using `setState` will be added to the buffer unless it's full.
+ * Any state actions dispatched using [setState] will be added to the buffer unless it's full.
  * Defaults to [Channel.BUFFERED].
  *
  * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
@@ -25,12 +25,13 @@ import io.uniflow.core.logger.UniFlowLogger
 import io.uniflow.core.threading.onMain
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 
 abstract class AndroidDataFlow(
-    defaultCapacity: Int = 10,
+    defaultCapacity: Int = Channel.BUFFERED,
     override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()
 ) : ViewModel(),
     DataFlow {

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
@@ -29,7 +29,11 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 
-abstract class AndroidDataFlow(defaultCapacity: Int = 10, override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()) : ViewModel(), DataFlow {
+abstract class AndroidDataFlow(
+    defaultCapacity: Int = 10,
+    override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()
+) : ViewModel(),
+    DataFlow {
 
     override val coroutineScope: CoroutineScope = viewModelScope
 

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.channels.actor
  * The default capacity of this `DataFlow`.
  * If [setState] or [sendEvent] are called in quick
  * succession, faster than the observers can be notified, then the buffer will be used.
- * Any `setState` or `sendEvent` calls will be added to the buffer unless it's full.
+ * Any state actions dispatched using `setState` will be added to the buffer unless it's full.
  * Defaults to [Channel.BUFFERED].
  *
  * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/AndroidDataFlow.kt
@@ -23,13 +23,25 @@ import io.uniflow.core.dispatcher.UniFlowDispatcher
 import io.uniflow.core.flow.*
 import io.uniflow.core.logger.UniFlowLogger
 import io.uniflow.core.threading.onMain
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.withContext
 
+/**
+ * Android implementation of [DataFlow].
+ * This is also a [ViewModel].
+ * Its [coroutineScope] equals [viewModelScope].
+ *
+ * @param defaultCapacity
+ * The default capacity of this `DataFlow`.
+ * If [setState] or [sendEvent] are called in quick
+ * succession, faster than the observers can be notified, then the buffer will be used.
+ * Any `setState` or `sendEvent` calls will be added to the buffer unless it's full.
+ * Defaults to [Channel.BUFFERED].
+ *
+ * @param defaultDispatcher The default [CoroutineDispatcher] on which state actions are dispatched.
+ * Defaults to [Dispatchers.IO].
+ */
 abstract class AndroidDataFlow(
     defaultCapacity: Int = Channel.BUFFERED,
     override val defaultDispatcher: CoroutineDispatcher = UniFlowDispatcher.dispatcher.io()


### PR DESCRIPTION
`AndroidDataFlow.defaultCapacitiy` defaulted to 10, which is a magic number. This PR changes it to `Channel.BUFFERED`, which defaults to 64.

This is a functional change.

However, it is unclear why a buffer of 10 or 64 would be preferable. What is clear is that concurrency should not be unlimited in general, so having a finite buffer seems reasonable.

Besides the buffer change, this PR adds KDoc to the AndroidDataFlow classes.
