### PR TITLE
feature/new_extension_for_flow_from_state

### DIFF
--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/DataFlowExt.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/DataFlowExt.kt
@@ -50,3 +50,25 @@ inline fun <reified T : UIState?> DataFlow.fromState(noinline onStateUpdate: Typ
         setState { sendEvent(UIEvent.BadOrWrongState(currentState)) }
     }
 }
+
+/**
+ * Execute update action from the given T state else send UIEvent.BadOrWrongState with current state
+ */
+inline fun <reified T : UIState?> DataFlow.stateFlowFrom(noinline stateFunctionFlow: StateFunctionFlow): StateAction {
+    return if (currentState is T) {
+        stateFlow(stateFunctionFlow)
+    } else {
+        setState { sendEvent(UIEvent.BadOrWrongState(currentState)) }
+    }
+}
+
+/**
+ * Execute update action from the given T state else send UIEvent.BadOrWrongState with current state
+ */
+inline fun <reified T : UIState> DataFlow.stateFlowFrom(noinline stateFunctionFlow: StateFunctionFlow, noinline errorFunction: ErrorFunction): StateAction {
+    return if (currentState is T) {
+        stateFlow(stateFunctionFlow, errorFunction)
+    } else {
+        setState { sendEvent(UIEvent.BadOrWrongState(currentState)) }
+    }
+}

--- a/uniflow-test/src/test/kotlin/io/uniflow/test/ActorFlowTest.kt
+++ b/uniflow-test/src/test/kotlin/io/uniflow/test/ActorFlowTest.kt
@@ -240,6 +240,33 @@ class ActorFlowTest {
     }
 
     @Test
+    fun `test flow from state`() = runBlocking {
+        dataFlow.getAll()
+        dataFlow.notifyFlowFromState()
+        delay(20)
+
+        assertEquals(UIState.Empty, dataFlow.states[0])
+        assertEquals(TodoListState(emptyList()), dataFlow.states[1])
+        assertEquals(UIState.Loading, dataFlow.states[2])
+        assertEquals(UIState.Success, dataFlow.states[3])
+
+        assertTrue(dataFlow.states.size == 4)
+        assertTrue(dataFlow.events.size == 0)
+    }
+
+    @Test
+    fun `test flow from state exception`() = runBlocking {
+        dataFlow.notifyFlowFromState()
+        delay(20)
+
+        assertEquals(UIState.Empty, dataFlow.states[0])
+        assertEquals(UIEvent.BadOrWrongState(UIState.Empty), dataFlow.events[0])
+
+        assertTrue(dataFlow.states.size == 1)
+        assertTrue(dataFlow.events.size == 1)
+    }
+
+    @Test
     fun `flow order test`() = runBlocking {
         assertEquals(UIState.Empty, dataFlow.states[0])
         dataFlow.states.clear()

--- a/uniflow-test/src/test/kotlin/io/uniflow/test/data/TodoStackActorFlow.kt
+++ b/uniflow-test/src/test/kotlin/io/uniflow/test/data/TodoStackActorFlow.kt
@@ -3,6 +3,7 @@ package io.uniflow.test.data
 import io.uniflow.core.flow.UIEvent
 import io.uniflow.core.flow.UIState
 import io.uniflow.core.flow.fromState
+import io.uniflow.core.flow.stateFlowFrom
 import io.uniflow.core.threading.onIO
 import kotlinx.coroutines.delay
 
@@ -89,6 +90,12 @@ class TodoStackActorFlow(private val repository: TodoRepository) : ListDataFlow(
     }
 
     fun testFlow() = stateFlow {
+        emit(UIState.Loading)
+        delay(10)
+        emit(UIState.Success)
+    }
+
+    fun notifyFlowFromState() = stateFlowFrom<TodoListState> {
         emit(UIState.Loading)
         delay(10)
         emit(UIState.Success)


### PR DESCRIPTION
This extension will give us the possibility to run `stateFlow` from a specific state otherwise it will send event `BadOrWrongState` with the current state 

```
fun update() = stateFlowFrom<UIState> {
        emit(UIState.Loading)
        delay(10)
        emit(UIState.Success)
    }