### PR TITLE
Fix test observer events comparision

### DIFF
--- a/uniflow-androidx-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
+++ b/uniflow-androidx-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
@@ -19,8 +19,8 @@ data class TestViewObserver(private val states: TestObserver<UIState>, private v
     fun hasState(state: UIState, index: Int): Boolean = states.elements[index] == state
     fun lastState(): UIState? = states.elements[states.elements.lastIndex]
     fun statesCount() = states.elements.count()
-    fun hasEvent(event: UIEvent) = events.elements.lastOrNull() == event
-    fun hasEvent(event: UIEvent, index: Int) = events.elements[index] == event
+    fun hasEvent(event: UIEvent) = events.elements.lastOrNull()?.take() == event
+    fun hasEvent(event: UIEvent, index: Int) = events.elements[index].take() == event
     fun eventsCount() = events.elements.count()
     fun lastEvent(): UIEvent? = events.elements[events.elements.lastIndex].take()
 }


### PR DESCRIPTION
`UIEvent` was compared to `Event<UIEvent>` which always fails