### PR TITLE
♻️ Parameterize `TestCoroutineDispatcher` in `TestDispatchers` and `TestDispatchersRule`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,19 @@ jobs:
       steps:
         - checkout
         - run:
-            name: Download dependencies
-            command: ./gradlew androidDependencies
-        - run:
             name: Run Tests
             command: ./test.sh
 
 
-  publish:
+  publish_build:
     <<: *android_config
     steps:
       - checkout
+       - run:
+          name: Install
+          command: ./install.sh
       - run:
-          name: Gradle build (debug)
+          name: Release
           command: ./release.sh
 
 workflows:
@@ -49,3 +49,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - publish_build:
+          tags:
+            only: /.*/
+          branches:
+            only:
+              - master

--- a/uniflow-test/src/main/kotlin/io/uniflow/test/dispatcher/TestDispatchers.kt
+++ b/uniflow-test/src/main/kotlin/io/uniflow/test/dispatcher/TestDispatchers.kt
@@ -25,8 +25,9 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
  * @author Arnaud Giuliani
  */
 @ExperimentalCoroutinesApi
-class TestDispatchers : UniFlowDispatcherConfiguration {
-    val testCoroutineDispatcher = TestCoroutineDispatcher()
+class TestDispatchers(
+    private val testCoroutineDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : UniFlowDispatcherConfiguration {
     override fun main() = testCoroutineDispatcher
     override fun default() = testCoroutineDispatcher
     override fun io() = testCoroutineDispatcher

--- a/uniflow-test/src/main/kotlin/io/uniflow/test/dispatcher/TestDispatchers.kt
+++ b/uniflow-test/src/main/kotlin/io/uniflow/test/dispatcher/TestDispatchers.kt
@@ -22,6 +22,10 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 /**
  * Dispatchers Configuration for Tests
  *
+ * @param testCoroutineDispatcher The [TestCoroutineDispatcher] used to replace the main, default
+ * and IO coroutine dispatchers of this `UniFlowDispatcherConfiguration`.
+ * Defaults to `TestCoroutineDispatcher()`.
+ *
  * @author Arnaud Giuliani
  */
 @ExperimentalCoroutinesApi

--- a/uniflow-test/src/main/kotlin/io/uniflow/test/rule/TestDispatchersRule.kt
+++ b/uniflow-test/src/main/kotlin/io/uniflow/test/rule/TestDispatchersRule.kt
@@ -5,6 +5,7 @@ import io.uniflow.core.dispatcher.UniFlowDispatcher
 import io.uniflow.test.dispatcher.TestDispatchers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -14,10 +15,10 @@ import org.junit.runner.Description
  * Setup Test Configuration Dispatcher
  */
 @ExperimentalCoroutinesApi
-class TestDispatchersRule : TestWatcher() {
-    private val testDispatchers = TestDispatchers()
-    val testCoroutineDispatcher = testDispatchers.testCoroutineDispatcher
-
+class TestDispatchersRule(
+    val testCoroutineDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher() {
+    private val testDispatchers: TestDispatchers = TestDispatchers(testCoroutineDispatcher)
     override fun starting(description: Description?) {
         Dispatchers.setMain(testCoroutineDispatcher)
         UniFlowDispatcher.dispatcher = testDispatchers

--- a/uniflow-test/src/main/kotlin/io/uniflow/test/rule/TestDispatchersRule.kt
+++ b/uniflow-test/src/main/kotlin/io/uniflow/test/rule/TestDispatchersRule.kt
@@ -12,7 +12,14 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 /**
- * Setup Test Configuration Dispatcher
+ * This rule [sets][setMain] the [`Main`][Dispatchers.Main] coroutine dispatcher before tests.
+ * Any coroutines running on [testCoroutineDispatcher] are
+ * [cleaned up][kotlinx.coroutines.test.TestCoroutineDispatcher.cleanupTestCoroutines] after tests,
+ * after which the main dispatcher is [reset][resetMain].
+ *
+ * @param testCoroutineDispatcher The [TestCoroutineDispatcher] used to replace the coroutine
+ * dispatchers used by UniFlow.
+ * Defaults to `TestCoroutineDispatcher()`.
  */
 @ExperimentalCoroutinesApi
 class TestDispatchersRule(


### PR DESCRIPTION
- `TestDispatchers` and `TestDispatchersRule` both use a `TestCoroutineDispatcher`. For flexibility of the API, I've parameterized these properties. Users can now provide their own `TestCoroutineDispatcher` instance, for ease of use.
- The parameters have defaults for backwards compatibility.
- I've added KDoc for the classes involved.