### PR TITLE
Fix failing assertion because of missing vararg to list conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,19 @@ jobs:
       steps:
         - checkout
         - run:
-            name: Download dependencies
-            command: ./gradlew androidDependencies
-        - run:
             name: Run Tests
             command: ./test.sh
 
 
-  publish:
+  publish_build:
     <<: *android_config
     steps:
       - checkout
+       - run:
+          name: Install
+          command: ./install.sh
       - run:
-          name: Gradle build (debug)
+          name: Release
           command: ./release.sh
 
 workflows:
@@ -49,3 +49,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - publish_build:
+          tags:
+            only: /.*/
+          branches:
+            only:
+              - master

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ data class WeatherState(val day : String, val temperature : String) : UIState()
 Publish state updates from your ViewModel:
 
 ```kotlin
-class WeatherDataFlow(val repo : WeatherRepository) : AndroidDataFlow() {
+class WeatherDataFlow(val repo : WeatherRepository) : AndroidDataFlow(defaultState = Empty) {
 
     fun getWeather() = action {
         // call to get data
@@ -150,6 +150,7 @@ fun `has some weather`() {
         
     // verify state
     dataFlow.assertReceived (
+    	UIState.Empty,
         WeatherState(weatherData.day, weatherData.temperature)
     )
 }

--- a/uniflow-android-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
+++ b/uniflow-android-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
@@ -34,9 +34,17 @@ class TestViewObserver {
     val lastValueOrNull
         get() = values.lastOrNull()
 
-    fun assertReceived(vararg any: UIData) = assert(this.values == any) { "Wrong values\nshould have [$any]\nbut was [${values}]" }
-    fun assertReceived(vararg states: UIState) = assert(this.states.values == states) { "Wrong values\nshould have [$states]\nbut was [${this.states.values}]" }
-    fun assertReceived(vararg events: UIEvent) = assert(this.events.values == events) { "Wrong values\nshould have [$events]\nbut was [${this.events.values}]" }
+    fun assertReceived(vararg any: UIData) {
+        assert(this.values == any.toList()) { "Wrong values\nshould have [${any.toList()}]\nbut was [${values}]" }
+    }
+
+    fun assertReceived(vararg states: UIState) {
+        assert(this.states.values == states.toList()) { "Wrong values\nshould have [${states.toList()}]\nbut was [${this.states.values}]" }
+    }
+
+    fun assertReceived(vararg events: UIEvent) {
+        assert(this.events.values == events.toList()) { "Wrong values\nshould have [${events.toList()}]\nbut was [${this.events.values}]" }
+    }
 }
 
 fun AndroidDataFlow.createTestObserver(): TestViewObserver {


### PR DESCRIPTION
Using the assertReceived function is failing for all assertions in the current version when using the SimpleTestObservers in an Android project. The conversion to a list is missing. I tried to adapt it the same way as it is in the AbstractSimpleFlow.

I really like the library btw, Great work!
Cheers