### PR TITLE
Checking state during action execution

### DIFF
--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/ActionFlow.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/ActionFlow.kt
@@ -4,6 +4,7 @@ import io.uniflow.core.flow.data.UIData
 import io.uniflow.core.flow.data.UIEvent
 import io.uniflow.core.flow.data.UIState
 import kotlinx.coroutines.flow.FlowCollector
+import kotlin.reflect.KClass
 
 
 typealias ActionFunction<T> = suspend ActionFlow.(T) -> (Unit)
@@ -16,6 +17,7 @@ enum class UIDataUpdateType {
 data class UIDataUpdate(val data: UIData, val type: UIDataUpdateType = UIDataUpdateType.PUBLISH)
 
 class ActionFlow(
+        val klass: KClass<UIState>,
         val onSuccess: ActionFunction<UIState>,
         val onError: ActionErrorFunction
 ) {


### PR DESCRIPTION
The state of the UIDataStore should be checked right before running the Action and not when trying to enqueue it.
Let's make a simple test:

Activity
```
class Activity: Activity{ 
    onCreate() { viewModel.onCreate() }
    onStart() { viewModel.onStart() }
    onResume() { viewModel.onResume() }
    ...
}
```
ViewModel
```
class MyViewModel: AndroidDataFlow(){
    ...
    fun onCreate() = actionOn<UIState.Empty>{ setState { MyState.Created } }
    fun onStart() = actionOn<MyState.Created>{ setState { MyState.Started } }
    fun onResume() = actionOn<MyState.Started>{ setState { MyState.Resumed } }
    ...
}
```

When `onCreate` is called, the `actionOn` will be enqueued successfully.
Now `onStart` will be called, but still the first action hasn't been executed yet, so the current state is still `UIState.Empty`. This will cause the submission of the `onStart` action to fail with `BadOrWrongState` event.

With this fix, the order of the actions will be preserved, since the check is done while running the action.
