### PR TITLE
Better events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@
 
 ## Changelog
 
+## 0.12.x
+
+### 0.12.0
+
+- `added` new Event/EventConsumer API to avoid need of take/peek operator, and help simplify the use of UIEvent.  
+
+
 ## 0.11.x
 
 ### 0.11.7

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // Koin
-    uniflow_version = '0.11.7'
+    uniflow_version = '0.12.0'
 
     // Kotlin
     kotlin_version = '1.3.72'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // Koin
-    uniflow_version = '0.12.0'
+    uniflow_version = '0.12.0-beta-1'
 
     // Kotlin
     kotlin_version = '1.3.72'

--- a/uniflow-android-test/src/main/java/io/uniflow/android/test/DataFlowObserver.kt
+++ b/uniflow-android-test/src/main/java/io/uniflow/android/test/DataFlowObserver.kt
@@ -9,7 +9,7 @@ import io.uniflow.core.flow.data.UIState
 
 data class MockedViewObserver(val states: Observer<UIState>, val events: Observer<Event<UIEvent>>) {
     infix fun hasState(state: UIState) = states.onChanged(state)
-    infix fun hasEvent(event: UIEvent) = events.onChanged(Event(event))
+    infix fun hasEvent(event: UIEvent) = events.onChanged(Event(content = event))
 }
 
 fun AndroidDataFlow.mockObservers(): MockedViewObserver {

--- a/uniflow-android-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
+++ b/uniflow-android-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
@@ -49,6 +49,6 @@ class TestViewObserver {
 fun AndroidDataFlow.createTestObserver(): TestViewObserver {
     val tester = TestViewObserver()
     dataPublisher.states.observeForever(tester.states)
-    dataPublisher.events.observeForever { tester.events.onChanged(it?.peek()) }
+    dataPublisher.events.observeForever { tester.events.onChanged(it?.content) }
     return tester
 }

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
@@ -44,7 +44,7 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
  * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
  */
 fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    val consumer = EventConsumer()
+    val consumer = EventConsumer(consumerId)
     vm.dataPublisher.events.observe(this, Observer { event ->
         event?.let {
             UniFlowLogger.debug("onEvents - $this <- $event")
@@ -52,3 +52,6 @@ fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit
         }
     })
 }
+
+internal val Any.consumerId: String
+    get() = this::class.simpleName ?: error("can't get consumerId for $this")

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
@@ -17,7 +17,7 @@ package io.uniflow.android.flow
 
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.Observer
-import io.uniflow.core.flow.data.Event
+import io.uniflow.core.flow.EventConsumer
 import io.uniflow.core.flow.data.UIEvent
 import io.uniflow.core.flow.data.UIState
 import io.uniflow.core.logger.UniFlowLogger
@@ -43,39 +43,12 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
 /**
  * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
  */
-fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (Event<*>) -> Unit) {
+fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
+    val consumer = EventConsumer()
     vm.dataPublisher.events.observe(this, Observer { event ->
         event?.let {
             UniFlowLogger.debug("onEvents - $this <- $event")
-            handleEvents(event)
-        }
-    })
-}
-
-/**
- * Listen incoming events & `peek` them (UIEvent) on given AndroidDataFlow
- */
-fun LifecycleOwner.onPeekEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    vm.dataPublisher.events.observe(this, Observer { event ->
-        event?.let {
-            event.peek().let {
-                UniFlowLogger.debug("onPeekEvents - $this <- $event")
-                handleEvents(it)
-            }
-        }
-    })
-}
-
-/**
- * Listen incoming events & `take` them (UIEvent) on given AndroidDataFlow
- */
-fun LifecycleOwner.onTakeEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    vm.dataPublisher.events.observe(this, Observer { event ->
-        event?.let {
-            event.take()?.let {
-                UniFlowLogger.debug("onTakeEvents - $this <- $event")
-                handleEvents(it)
-            }
+            consumer.onEvent(event)
         }
     })
 }

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/DataFlowObserver.kt
@@ -32,10 +32,18 @@ import io.uniflow.core.logger.UniFlowLogger
  * Listen incoming states (UIState) on given AndroidDataFlow
  */
 fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit) {
+    var lastState: UIState? = null
     vm.dataPublisher.states.observe(this, Observer { state: UIState? ->
+        // TODO Extract generic State observer
         state?.let {
-            UniFlowLogger.debug("onStates - $this <- $state")
-            handleStates(state)
+            UniFlowLogger.debug("onStates - $this - last state: $lastState")
+            if (lastState != state) {
+                UniFlowLogger.debug("onStates - $this <- $state")
+                handleStates(state)
+                lastState = state
+            } else {
+                UniFlowLogger.debug("onStates - already received -  $this <- $state")
+            }
         }
     })
 }
@@ -46,9 +54,12 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
 fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
     val consumer = EventConsumer(consumerId)
     vm.dataPublisher.events.observe(this, Observer { event ->
+        // TODO Extract generic Event observer
         event?.let {
-            UniFlowLogger.debug("onEvents - $this <- $event")
-            consumer.onEvent(event)
+            consumer.onEvent(event)?.let {
+                UniFlowLogger.debug("onEvents - $this <- $event")
+                handleEvents(it)
+            } ?: UniFlowLogger.debug("onEvents - already received - $this <- $event")
         }
     })
 }

--- a/uniflow-android/src/main/java/io/uniflow/android/flow/LiveDataPublisher.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/flow/LiveDataPublisher.kt
@@ -27,7 +27,7 @@ class LiveDataPublisher(defaultState: UIState) : UIDataPublisher {
 
     override suspend fun publishEvent(event: UIEvent) {
         onMain(immediate = true) {
-            _events.value = Event(event)
+            _events.value = Event(content = event)
         }
     }
 }

--- a/uniflow-androidx-test/src/main/java/io/uniflow/android/test/MockedViewObserver.kt
+++ b/uniflow-androidx-test/src/main/java/io/uniflow/android/test/MockedViewObserver.kt
@@ -9,7 +9,7 @@ import io.uniflow.core.flow.data.UIState
 
 data class MockedViewObserver(val states: Observer<UIState>, val events: Observer<Event<UIEvent>>) {
     infix fun hasState(state: UIState) = states.onChanged(state)
-    infix fun hasEvent(event: UIEvent) = events.onChanged(Event(event))
+    infix fun hasEvent(event: UIEvent) = events.onChanged(Event(content = event))
 }
 
 fun AndroidDataFlow.mockObservers(): MockedViewObserver {

--- a/uniflow-androidx-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
+++ b/uniflow-androidx-test/src/main/java/io/uniflow/android/test/SimpleTestObservers.kt
@@ -47,6 +47,6 @@ class TestViewObserver {
 fun AndroidDataFlow.createTestObserver(): TestViewObserver {
     val tester = TestViewObserver()
     dataPublisher.states.observeForever(tester.states)
-    dataPublisher.events.observeForever { tester.events.onChanged(it.peek()) }
+    dataPublisher.events.observeForever { tester.events.onChanged(it.content) }
     return tester
 }

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
@@ -44,7 +44,7 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
  * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
  */
 fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    val consumer = EventConsumer()
+    val consumer = EventConsumer(consumerId)
     vm.dataPublisher.events.observe(this, Observer { event ->
         event?.let {
             UniFlowLogger.debug("onEvents - $this <- $event")
@@ -52,3 +52,6 @@ fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit
         }
     })
 }
+
+internal val Any.consumerId: String
+    get() = this::class.simpleName ?: error("can't get consumerId for $this")

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
@@ -17,7 +17,7 @@ package io.uniflow.androidx.flow
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
-import io.uniflow.core.flow.data.Event
+import io.uniflow.core.flow.EventConsumer
 import io.uniflow.core.flow.data.UIEvent
 import io.uniflow.core.flow.data.UIState
 import io.uniflow.core.logger.UniFlowLogger
@@ -43,39 +43,12 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
 /**
  * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
  */
-fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (Event<*>) -> Unit) {
+fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
+    val consumer = EventConsumer()
     vm.dataPublisher.events.observe(this, Observer { event ->
         event?.let {
             UniFlowLogger.debug("onEvents - $this <- $event")
-            handleEvents(event)
-        }
-    })
-}
-
-/**
- * Listen incoming events & `peek` them (UIEvent) on given AndroidDataFlow
- */
-fun LifecycleOwner.onPeekEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    vm.dataPublisher.events.observe(this, Observer { event ->
-        event?.let {
-            event.peek().let {
-                UniFlowLogger.debug("onPeekEvents - $this <- $event")
-                handleEvents(it)
-            }
-        }
-    })
-}
-
-/**
- * Listen incoming events & `take` them (UIEvent) on given AndroidDataFlow
- */
-fun LifecycleOwner.onTakeEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
-    vm.dataPublisher.events.observe(this, Observer { event ->
-        event?.let {
-            event.take()?.let {
-                UniFlowLogger.debug("onTakeEvents - $this <- $event")
-                handleEvents(it)
-            }
+            consumer.onEvent(event)
         }
     })
 }

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/DataFlowObserver.kt
@@ -32,10 +32,18 @@ import io.uniflow.core.logger.UniFlowLogger
  * Listen incoming states (UIState) on given AndroidDataFlow
  */
 fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit) {
+    var lastState: UIState? = null
     vm.dataPublisher.states.observe(this, Observer { state: UIState? ->
+        // TODO Extract generic State observer
         state?.let {
-            UniFlowLogger.debug("onStates - $this <- $state")
-            handleStates(state)
+            UniFlowLogger.debug("onStates - $this - last state: $lastState")
+            if (lastState != state) {
+                UniFlowLogger.debug("onStates - $this <- $state")
+                handleStates(state)
+                lastState = state
+            } else {
+                UniFlowLogger.debug("onStates - already received -  $this <- $state")
+            }
         }
     })
 }
@@ -46,9 +54,12 @@ fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: (UIState) -> Unit
 fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit) {
     val consumer = EventConsumer(consumerId)
     vm.dataPublisher.events.observe(this, Observer { event ->
+        // TODO Extract generic Event observer
         event?.let {
-            UniFlowLogger.debug("onEvents - $this <- $event")
-            consumer.onEvent(event)
+            consumer.onEvent(event)?.let {
+                UniFlowLogger.debug("onEvents - $this <- $event")
+                handleEvents(it)
+            } ?: UniFlowLogger.debug("onEvents - already received - $this <- $event")
         }
     })
 }

--- a/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/LiveDataPublisher.kt
+++ b/uniflow-androidx/src/main/java/io/uniflow/androidx/flow/LiveDataPublisher.kt
@@ -27,7 +27,7 @@ class LiveDataPublisher(defaultState: UIState) : UIDataPublisher {
 
     override suspend fun publishEvent(event: UIEvent) {
         onMain(immediate = true) {
-            _events.value = Event(event)
+            _events.value = Event(content = event)
         }
     }
 }

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
@@ -5,24 +5,15 @@ import io.uniflow.core.flow.data.UIEvent
 import io.uniflow.core.logger.UniFlowLogger
 
 /**
- * Help receive & consume event.
+ * Help consume events & extract content
  */
-class EventConsumer {
-    private val receivedIds: MutableList<String> = arrayListOf()
+data class EventConsumer(val id : String) {
 
-    fun onEvent(event: Event<UIEvent>): UIEvent? {
-        return if (canConsumeEvent(event)) {
-            consumeEvent(event)
-        } else {
-            UniFlowLogger.debug("$this has already received $event")
-            null
-        }
+    init {
+        UniFlowLogger.debug("$this has been created")
     }
 
-    private fun canConsumeEvent(event: Event<UIEvent>): Boolean = receivedIds.contains(event.id)
-    private fun consumeEvent(event: Event<UIEvent>): UIEvent {
-        receivedIds.add(event.id)
-        UniFlowLogger.debug("$this consumed $event")
-        return event.content
+    fun onEvent(event: Event<UIEvent>): UIEvent? {
+        return event.getContentForConsumer(this)
     }
 }

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
@@ -1,0 +1,28 @@
+package io.uniflow.core.flow
+
+import io.uniflow.core.flow.data.Event
+import io.uniflow.core.flow.data.UIEvent
+import io.uniflow.core.logger.UniFlowLogger
+
+/**
+ * Help receive & consume event.
+ */
+class EventConsumer {
+    private val receivedIds: MutableList<String> = arrayListOf()
+
+    fun onEvent(event: Event<UIEvent>): UIEvent? {
+        return if (canConsumeEvent(event)) {
+            consumeEvent(event)
+        } else {
+            UniFlowLogger.debug("$this has already received $event")
+            null
+        }
+    }
+
+    private fun canConsumeEvent(event: Event<UIEvent>): Boolean = receivedIds.contains(event.id)
+    private fun consumeEvent(event: Event<UIEvent>): UIEvent {
+        receivedIds.add(event.id)
+        UniFlowLogger.debug("$this consumed $event")
+        return event.content
+    }
+}

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/EventConsumer.kt
@@ -7,7 +7,7 @@ import io.uniflow.core.logger.UniFlowLogger
 /**
  * Help consume events & extract content
  */
-data class EventConsumer(val id : String) {
+data class EventConsumer(val id: String) {
 
     init {
         UniFlowLogger.debug("$this has been created")

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/data/Event.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/data/Event.kt
@@ -16,11 +16,35 @@
 
 package io.uniflow.core.flow.data
 
+import io.uniflow.core.flow.EventConsumer
+import io.uniflow.core.logger.UniFlowLogger
 import java.util.*
 
 /**
- * Data Flow Event wrapper
+ * Event wrapper
+ *
+ * Help send content to EventConsumer
  *
  * @author Arnaud Giuliani
  */
-data class Event<out T : UIEvent>(val id: String = UUID.randomUUID().toString(), val content: T)
+data class Event<out T : UIEvent>(val id: String = UUID.randomUUID().toString(), val content: T) {
+
+    private val consumerIds = arrayListOf<String>()
+
+    private fun hasNotBeenSentTo(consumer: EventConsumer): Boolean = !consumerIds.contains(consumer.id)
+
+    private fun registerConsumer(consumer: EventConsumer) {
+        consumerIds.add(consumer.id)
+    }
+
+    fun getContentForConsumer(consumer: EventConsumer): UIEvent? {
+        return if (hasNotBeenSentTo(consumer)) {
+            registerConsumer(consumer)
+            UniFlowLogger.debug("$consumer received $content")
+            content
+        } else {
+            UniFlowLogger.debug("$consumer skipped - already received $content")
+            null
+        }
+    }
+}

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/data/Event.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/data/Event.kt
@@ -16,38 +16,11 @@
 
 package io.uniflow.core.flow.data
 
+import java.util.*
+
 /**
  * Data Flow Event wrapper
  *
  * @author Arnaud Giuliani
  */
-data class Event<out T : UIEvent>(private val content: T) {
-
-    var hasBeenHandled = false
-        private set // Allow external read but not write
-
-    /**
-     * Returns the content and put the event has handled
-     */
-    fun take(): T? {
-        return if (hasBeenHandled) {
-            null
-        } else {
-            hasBeenHandled = true
-            content
-        }
-    }
-
-    /**
-     * Return and execute code on given value
-     * put the event has handled
-     */
-    fun take(code: (T) -> Unit) {
-        take()?.let { code(it) }
-    }
-
-    /**
-     * Returns the content, even if it's already been handled.
-     */
-    fun peek(): T = content
-}
+data class Event<out T : UIEvent>(val id: String = UUID.randomUUID().toString(), val content: T)

--- a/uniflow-test/src/test/kotlin/io/uniflow/test/impl/ValidateDataFlowTest.kt
+++ b/uniflow-test/src/test/kotlin/io/uniflow/test/impl/ValidateDataFlowTest.kt
@@ -1,11 +1,18 @@
 package io.uniflow.test.impl
 
 import io.uniflow.core.flow.data.UIState
+import io.uniflow.core.logger.UniFlowLogger
 import io.uniflow.test.validate.validate
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
 class ValidateDataFlowTest {
+
+    @Before
+    fun before(){
+        UniFlowLogger.default()
+    }
 
     @Test
     fun `test bad Dataflow`() {

--- a/uniflow-test/src/test/kotlin/io/uniflow/test/impl/ValidateDataFlowTest.kt
+++ b/uniflow-test/src/test/kotlin/io/uniflow/test/impl/ValidateDataFlowTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class ValidateDataFlowTest {
 
     @Before
-    fun before(){
+    fun before() {
         UniFlowLogger.default()
     }
 


### PR DESCRIPTION
Hi Team,

I propose to get rid of peek/take operations & propose a better way to use events. 

`EventConsumer` help consume received events.
`Event` wrapper class, to let extract content regarding if the consumer has already consumed it or not.