### PR TITLE
Remove restriction of pushing state 

### DIFF
--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataObserver.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataObserver.kt
@@ -48,24 +48,17 @@ fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: (UIEvent) -> Unit
  * Listen incoming states (UIState) on given AndroidDataFlow
  */
 fun LiveDataPublisher.onStates(owner: LifecycleOwner, handleStates: (UIState) -> Unit) {
-    var lastState: UIState? = null
-    states.observe(owner, Observer { state: UIState? ->
+    states.observe(owner, { state: UIState? ->
         state?.let {
-            UniFlowLogger.debug("onStates - $owner - last state: $lastState")
-            if (lastState != state) {
-                UniFlowLogger.debug("onStates - $owner <- $state")
-                handleStates(state)
-                lastState = state
-            } else {
-                UniFlowLogger.debug("onStates - already received -  $owner <- $state")
-            }
+            UniFlowLogger.debug("onStates - $owner <- $state")
+            handleStates(state)
         }
     })
 }
 
 fun LiveDataPublisher.onEvents(owner: LifecycleOwner, handleEvents: (UIEvent) -> Unit) {
     val consumer = EventConsumer(owner.consumerId)
-    events.observe(owner, Observer { event ->
+    events.observe(owner, { event ->
         event?.let {
             consumer.onEvent(event)?.let {
                 UniFlowLogger.debug("onEvents - $owner <- $event")

--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
@@ -27,9 +27,7 @@ open class LiveDataPublisher(
     override suspend fun publishState(state: UIState, pushStateUpdate: Boolean) {
         onMain(immediate = true) {
             UniFlowLogger.debug("$tag --> $state")
-            if (pushStateUpdate) {
-                _states.value = state
-            }
+            _states.value = state
         }
     }
 

--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
@@ -27,7 +27,9 @@ open class LiveDataPublisher(
     override suspend fun publishState(state: UIState, pushStateUpdate: Boolean) {
         onMain(immediate = true) {
             UniFlowLogger.debug("$tag --> $state")
-            _states.value = state
+            if (pushStateUpdate) {
+                _states.value = state
+            }
         }
     }
 


### PR DESCRIPTION
Remove the restriction of pushing state from `onState`. There are a few reasons why we should remove it :
 
 <img src="https://user-images.githubusercontent.com/23320285/120000378-08b4bf80-bfd3-11eb-80b3-2c5981daa0b2.png" width="400" height="250">

When we have a similar implementation it is not going to work when we will have the same state, so our output will be 
1. Loading - Event 
2. OurState - State 
When we will execute this method one more time we are going to have only 
3. Loading - Event 
Because our `LiveDataPublisher.onStates`  will have this state already, I'm not sure if this is something that we want to have only because we should be responsible for the state or event that we are emitting. 

I'm not sure if this is clear enough, I'm happy to provide more information 

