### PR TITLE
Proposal for consistent handling of states & events with Jetpack Compose

### DIFF
--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -8,4 +8,5 @@ ext {
     androidx_lib_version = "1.2.0"
     androidx_vm_version = '2.3.0'
 	androidx_lifecycle_version = '2.2.0'
+    androidx_compose_version = '1.0.1'
 }

--- a/uniflow-android/build.gradle
+++ b/uniflow-android/build.gradle
@@ -36,6 +36,7 @@ dependencies {
         exclude group: "androidx.legacy"
     }
     api "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidx_vm_version"
+    api "androidx.compose.runtime:runtime-livedata:$androidx_compose_version"
 }
 
 apply from: '../gradle/sources-android.gradle'

--- a/uniflow-android/src/main/java/io/uniflow/android/compose/LiveDataComposer.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/compose/LiveDataComposer.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uniflow.android.compose
+
+import android.annotation.SuppressLint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleOwner
+import io.uniflow.android.AndroidDataFlow
+import io.uniflow.android.consumerId
+import io.uniflow.android.livedata.LiveDataPublisher
+import io.uniflow.core.flow.data.EventConsumer
+import io.uniflow.core.flow.data.UIEvent
+import io.uniflow.core.flow.data.UIState
+import io.uniflow.core.logger.UniFlowLogger
+
+/**
+ * DataFlow Observers for states & events handled with Jetpack Compose
+ *
+ * @author Stephan Schuster
+ */
+
+/**
+ * Listen incoming states (UIState) on given AndroidDataFlow
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+fun Fragment.onStates(vm: AndroidDataFlow, handleStates: @Composable (UIState) -> Unit) {
+    (vm.defaultDataPublisher as? LiveDataPublisher)?.onStates(this.viewLifecycleOwner, handleStates)
+}
+
+/**
+ * Listen incoming states (UIState) on given AndroidDataFlow
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+fun LifecycleOwner.onStates(vm: AndroidDataFlow, handleStates: @Composable (UIState) -> Unit) {
+    (vm.defaultDataPublisher as? LiveDataPublisher)?.onStates(this, handleStates)
+}
+
+/**
+ * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+fun Fragment.onEvents(vm: AndroidDataFlow, handleEvents: @Composable (UIEvent) -> Unit) {
+    (vm.defaultDataPublisher as? LiveDataPublisher)?.onEvents(this.viewLifecycleOwner, this.consumerId, handleEvents)
+}
+
+/**
+ * Listen incoming events (Event<UIEvent>) on given AndroidDataFlow
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+fun LifecycleOwner.onEvents(vm: AndroidDataFlow, handleEvents: @Composable (UIEvent) -> Unit) {
+    (vm.defaultDataPublisher as? LiveDataPublisher)?.onEvents(this, this.consumerId, handleEvents)
+}
+
+
+/**
+ * Listen incoming states (UIState) on given AndroidDataFlow
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+fun LiveDataPublisher.onStates(owner: LifecycleOwner, handleStates: @Composable (UIState) -> Unit) {
+    states.observeAsState().value?.let { state ->
+        UniFlowLogger.debug("onStates - $owner <- $state")
+        handleStates(state)
+    }
+}
+
+@SuppressLint("ComposableNaming")
+@Composable
+fun LiveDataPublisher.onEvents(owner: LifecycleOwner, ownerId: String, handleEvents: @Composable (UIEvent) -> Unit) {
+    val consumer = EventConsumer(ownerId)
+    events.observeAsState().value?.let { event ->
+        consumer.onEvent(event)?.let {
+            UniFlowLogger.debug("onEvents - $owner <- $event")
+            handleEvents(it)
+        } ?: UniFlowLogger.debug("onEvents - already received - $owner <- $event")
+    }
+}


### PR DESCRIPTION
Do you think something like this would be helpful for people using Jetpack Compose?
The idea is to make things simpler and more consistent with the rest of the framework.

Basically it's a copy of LiveDataObserver.kt with @Composable in it's API.
I am new to those things, so please check if the code is correct, especially the event part.
Feel free to adjust it as you see fit. This is just a proposal. I am not insisting on anything.

Due to the new dependency you might also want to put this into a separate module.
On the other hand, I would assume that "uniflow-android" is also fine for just one class.
Mid-term most people will use Jetpack Compose and have this dependency anyways.