### PR TITLE
Fix #87 by avoiding double error log

### DIFF
--- a/uniflow-android-test/src/test/java/io/uniflow/android/test/sync/OtherTests.kt
+++ b/uniflow-android-test/src/test/java/io/uniflow/android/test/sync/OtherTests.kt
@@ -1,0 +1,58 @@
+package io.uniflow.android.test.sync
+
+import io.uniflow.android.AndroidDataFlow
+import io.uniflow.core.flow.actionOn
+import io.uniflow.core.flow.data.UIEvent
+import io.uniflow.core.flow.data.UIState
+import io.uniflow.core.logger.Logger
+import io.uniflow.core.logger.UniFlowLogger
+import io.uniflow.test.rule.UniflowTestDispatchersRule
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class OtherTests {
+    companion object {
+        private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    }
+
+    @get:Rule
+    val uniflowTestDispatchersRule = UniflowTestDispatchersRule(testCoroutineDispatcher)
+
+    @Test
+    fun `bad or wrong state is logged once`() {
+        val logger = object : Logger {
+            val messages = mutableListOf<String>()
+
+            override fun debug(message: String) {
+                println("[dbg] - $message")
+            }
+
+            override fun log(message: String) {
+                println("[log] - $message")
+            }
+
+            override fun logError(errorMessage: String, error: Exception?) {
+                messages += errorMessage
+                println("[err] - $errorMessage")
+            }
+
+            override fun logEvent(event: UIEvent) {
+            }
+
+            override fun logState(state: UIState) {
+            }
+        }
+
+        UniFlowLogger.init(logger)
+
+        val androidDataFlow = object : AndroidDataFlow(defaultState = UIState.Empty) {
+            fun foo() = actionOn<UIState.Loading> {}
+        }
+
+        androidDataFlow.foo() // Should log an uncaught error about a BadOrWrongStateException
+
+        assertEquals(1, logger.messages.size)
+    }
+}

--- a/uniflow-android-test/src/test/java/io/uniflow/android/test/sync/OtherTests.kt
+++ b/uniflow-android-test/src/test/java/io/uniflow/android/test/sync/OtherTests.kt
@@ -54,5 +54,7 @@ class OtherTests {
         androidDataFlow.foo() // Should log an uncaught error about a BadOrWrongStateException
 
         assertEquals(1, logger.messages.size)
+        
+        UniFlowLogger.default()
     }
 }

--- a/uniflow-core/src/main/kotlin/io/uniflow/core/flow/ActionReducer.kt
+++ b/uniflow-core/src/main/kotlin/io/uniflow/core/flow/ActionReducer.kt
@@ -58,7 +58,9 @@ open class ActionReducer(
             UniFlowLogger.debug("$tag - completed: $action")
         } catch (e: Exception) {
             UniFlowLogger.debug("$tag - error: $action")
-            action.onError(e, currentState)
+            if (e !is BadOrWrongStateException){
+                action.onError(e, currentState)
+            }
         }
     }
 


### PR DESCRIPTION
This PR is fixing double error logging when having `BadOrWrongStateException` 