### PR TITLE
Expose current state so we can restore it

### DIFF
--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataPublisher.kt
@@ -22,7 +22,7 @@ open class LiveDataPublisher(
     internal val _events = MutableLiveData<Event<UIEvent>>()
     val events: LiveData<Event<UIEvent>> = _events
 
-    private var _currentState: UIState = defaultState
+    internal var _currentState: UIState = defaultState
     override fun getState(): UIState = _currentState
 
     override suspend fun publishState(state: UIState, pushStateUpdate: Boolean) {

--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/PersistentLiveDataPublisher.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/PersistentLiveDataPublisher.kt
@@ -19,6 +19,7 @@ class PersistentLiveDataPublisher(
         return savedStateHandle.get<UIState>(tag)?.let { state ->
             UniFlowLogger.debug("$tag --> restore --> $state")
             _states.value = state
+            _currentState = state
             state
         }
     }


### PR DESCRIPTION
Expose current state so it can be restored in `PersistentLiveDataPublisher` init.

This should fix the issue #90 