### PR TITLE
Add typed state and event handlers

### DIFF
--- a/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataObserver.kt
+++ b/uniflow-android/src/main/java/io/uniflow/android/livedata/LiveDataObserver.kt
@@ -82,3 +82,51 @@ fun LiveDataPublisher.onEvents(owner: LifecycleOwner, ownerId: String, handleEve
         }
     })
 }
+
+/**
+ * Only reacts to state changes of a specific type, useful for exhaustive when statements
+ */
+inline fun <reified TState : UIState> Fragment.onStatesOfType(
+    vm: AndroidDataFlow,
+    crossinline handleStates: (TState) -> Unit
+) {
+    onStates(vm) {
+        if (it is TState) handleStates(it)
+    }
+}
+
+/**
+ * Only handles events are a specific type, useful for exhaustive when statements
+ */
+inline fun <reified TEvent : UIEvent> Fragment.onEventsOfType(
+    vm: AndroidDataFlow,
+    crossinline handleEvents: (TEvent) -> Unit
+) {
+    onEvents(vm) {
+        if (it is TEvent) handleEvents(it)
+    }
+}
+
+/**
+ * Only reacts to state changes of a specific type, useful for exhaustive when statements
+ */
+inline fun <reified TState : UIState> LifecycleOwner.onStatesOfType(
+    vm: AndroidDataFlow,
+    crossinline handleStates: (TState) -> Unit
+) {
+    onStates(vm) {
+        if (it is TState) handleStates(it)
+    }
+}
+
+/**
+ * Only handles events are a specific type, useful for exhaustive when statements
+ */
+inline fun <reified TEvent : UIEvent> LifecycleOwner.onEventsOfType(
+    vm: AndroidDataFlow,
+    crossinline handleEvents: (TEvent) -> Unit
+) {
+    onEvents(vm) {
+        if (it is TEvent) handleEvents(it)
+    }
+}


### PR DESCRIPTION
Uniflow exposes some extension functions for observing states and events in your UI. `onStates` & `onEvents` work great but only they provide open types. This is useful when you are dealing with states and events of multiple types. For example:

```kotlin
onStates(viewModel) {
    when (it) {
        is UIState.Loading -> handleLoading()
        is MyCustomExampleState.Success -> handleSuccess(it.stuff)
    }
}
```
In this example `it` is `UIState`.
But often we will actually only use our custom states and events like this:

```kotlin
onStates(viewModel) {
    when (it) {
        is MyCustomExampleState.Loading -> handleLoading()
        is MyCustomExampleState.Success -> handleSuccess(it.stuff)
    }
}
```
`MyCustomExampleState` would typically be a sealed class and we would want to handle it exhaustively but there are no warnings because it is `UIState` which is an open class.

These extensions will provide us with strongly typed state and event handlers which means you will be warned if you don't handle all permutations of the sealed class.

```kotlin
onStatesOfType<MyCustomExampleState>(viewModel) {
    when (it) {
        is MyCustomExampleState.Loading -> handleLoading()
        is MyCustomExampleState.Success -> handleSuccess(it.stuff)
    }
}
```